### PR TITLE
Adding Requested Featured: External Build Tools

### DIFF
--- a/commands/setup.js
+++ b/commands/setup.js
@@ -5,6 +5,7 @@ const prompt = require('prompt')
 const slug = require('slug')
 
 const config = require('../lib/config')()
+const builds = require('../lib/builds')
 
 module.exports = async () => {
   const setDefaults =
@@ -129,6 +130,9 @@ module.exports = async () => {
           newConfig[client] = {}
         }
 
+        // Fetch Build Scripts from Project Directory
+        const builders = builds(result.d)
+
         // Create / Overwrite SFCC Instance for Client
         newConfig[client][alias] = {
           h: result.h,
@@ -136,7 +140,8 @@ module.exports = async () => {
           a: result.a,
           d: result.d,
           u: result.u,
-          p: result.p
+          p: result.p,
+          b: builders
         }
 
         // Write Config File

--- a/commands/watch.js
+++ b/commands/watch.js
@@ -63,7 +63,7 @@ module.exports = options => {
 
             exec(cmd, (err, data, stderr) => {
               if (err || stderr) {
-                console.error(err, stderr)
+                console.log(chalk.red.bold(`✖ Build Error: ${err} {stderr}`))
               }
             })
           }
@@ -73,13 +73,12 @@ module.exports = options => {
 
     // Watch for File Changes
     watcher.on('change', file => {
-      // Check if we need to start a build
-      buildCheck(file)
       upload({file, spinner, selected, client, instance, options})
+      buildCheck(file)
     })
     watcher.on('add', file => {
-      buildCheck(file)
       upload({file, spinner, selected, client, instance, options})
+      buildCheck(file)
     })
 
     // @TODO: Watch for Removing Files

--- a/lib/builds.js
+++ b/lib/builds.js
@@ -1,0 +1,138 @@
+const convert = require('xml-js')
+const fs = require('fs')
+const os = require('os').type()
+const path = require('path')
+const slug = require('slug')
+
+module.exports = project => {
+  let externalToolBuilders = []
+  let build = {}
+
+  // Look for *.launch files in .externalToolBuilders folder
+  fs.readdirSync(project).map(fileName => {
+    const filePath = path.join(project, fileName)
+    if (fs.statSync(filePath).isDirectory()) {
+      const buildPath = path.join(filePath, '.externalToolBuilders')
+      if (fs.existsSync(buildPath) && fs.statSync(buildPath).isDirectory()) {
+        fs.readdirSync(buildPath).map(buildFile => {
+          if (path.extname(buildFile) === '.launch') {
+            externalToolBuilders.push(path.join(buildPath, buildFile))
+          }
+        })
+      }
+    }
+  })
+
+  // Loop through found .externalToolBuilders files and parse build instructions
+  if (externalToolBuilders.length > 0) {
+    externalToolBuilders.map(launch => {
+      const xml = fs.readFileSync(launch)
+      const json = convert.xml2json(xml)
+      const builder = json ? JSON.parse(json) : null
+      const name = slug(
+        path.basename(path.dirname(path.dirname(launch))).replace('_', '-') +
+          '_' +
+          path.basename(launch).replace('.launch', ''),
+        {lower: true, replacement: '-'}
+      )
+
+      // setup placeholder for this config file
+      build[name] = {
+        enabled: false,
+        watch: [],
+        cmd: {
+          basedir: null,
+          exec: null
+        }
+      }
+
+      if (
+        builder &&
+        typeof builder.elements !== 'undefined' &&
+        builder.elements.length === 1 &&
+        builder.elements[0].name === 'launchConfiguration' &&
+        builder.elements[0].elements
+      ) {
+        builder.elements[0].elements.map(elm => {
+          // Get Watch Directories
+          if (elm.attributes.key === 'org.eclipse.ui.externaltools.ATTR_BUILD_SCOPE') {
+            const buildScopeJson = convert.xml2json(
+              elm.attributes.value.replace('${working_set:', '').replace(/}$/, '')
+            )
+            const buildScope = buildScopeJson ? JSON.parse(buildScopeJson) : null
+
+            if (
+              buildScope &&
+              typeof buildScope.elements !== 'undefined' &&
+              buildScope.elements.length === 1 &&
+              buildScope.elements[0].name === 'resources' &&
+              builder.elements[0].elements
+            ) {
+              buildScope.elements[0].elements.map(buildSrc => {
+                build[name].watch.push(buildSrc.attributes.path)
+              })
+            }
+          }
+
+          // Check if we should enable this build
+          if (elm.attributes.key === 'org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS') {
+            build[name].enabled =
+              elm.attributes.value.includes('full') ||
+              elm.attributes.value.includes('incremental') ||
+              elm.attributes.value.includes('auto')
+          }
+
+          // Get Build Instructuctions
+          if (elm.attributes.key === 'org.eclipse.ui.externaltools.ATTR_LOCATION') {
+            const buildFilePath = elm.attributes.value.replace('${workspace_loc:', '').replace(/}$/, '')
+            const buildFileXml = fs.readFileSync(path.join(project, buildFilePath))
+            const buildFileJson = convert.xml2json(buildFileXml)
+            const buildInstructions = buildFileJson ? JSON.parse(buildFileJson) : null
+
+            if (
+              buildInstructions &&
+              typeof buildInstructions.elements !== 'undefined' &&
+              buildInstructions.elements.length === 1 &&
+              buildInstructions.elements[0].name === 'project' &&
+              buildInstructions.elements[0].elements
+            ) {
+              buildInstructions.elements[0].elements.map(buildInstruction => {
+                build[name].cmd.basedir =
+                  typeof buildInstructions.elements[0].attributes.basedir !== 'undefined'
+                    ? path.join(
+                        project,
+                        path.basename(path.dirname(path.dirname(launch))),
+                        buildInstructions.elements[0].attributes.basedir
+                      )
+                    : null
+                buildInstruction.elements.map(instruction => {
+                  if (instruction.name === 'exec') {
+                    let exec = instruction.attributes.executable
+                    if (
+                      (exec === 'cmd' && os === 'Windows_NT') ||
+                      (exec !== 'cmd' && (os === 'Darwin' || os === 'Linux'))
+                    ) {
+                      instruction.elements.map(arg => {
+                        if (arg.name === 'arg') {
+                          exec = exec.concat(' ' + arg.attributes.value)
+                        }
+                      })
+
+                      // Replace commands that are not needed outside Eclipse
+                      exec = exec.replace('/bin/bash -l -c ', '')
+                      exec = exec.replace(/\${basedir}/g, build[name].cmd.basedir)
+
+                      build[name].cmd.exec = exec
+                    }
+                  }
+                })
+              })
+            }
+          }
+        })
+      }
+    })
+  }
+
+  return build
+}

--- a/lib/search.js
+++ b/lib/search.js
@@ -11,7 +11,7 @@ module.exports = async (selected, groups, options) => {
   const excluding = options.exclude && options.exclude.length > 0 ? ` '${options.exclude.join(', ')}'` : ''
   const filters = options.filter && options.filter.length > 0 ? ` containing '${options.filter}'` : ''
 
-  const text = `Searching${including}${excluding} Logs${filters} [Ctrl-C to Cancel]`
+  const text = chalk.bold(`Searching${including}${excluding} Logs${filters}`).concat(' [Ctrl-C to Cancel]\n')
   const spinner = ora(text)
   const output = fn => {
     spinner.stop()

--- a/lib/tail.js
+++ b/lib/tail.js
@@ -11,7 +11,7 @@ module.exports = async (selected, logs, groups, options) => {
   const excluding = options.exclude && options.exclude.length > 0 ? ` '${options.exclude.join(', ')}'` : ''
   const filters = options.filter && options.filter.length > 0 ? ` containing '${options.filter}'` : ''
 
-  const text = `Streaming${including}${excluding} Logs${filters} [Ctrl-C to Cancel]`
+  const text = chalk.bold(`Streaming${including}${excluding} Logs${filters}`).concat(' [Ctrl-C to Cancel]\n')
   const spinner = ora(text)
   const output = fn => {
     spinner.stop()

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const pRetry = require('p-retry')
+const chalk = require('chalk')
 
 const logger = require('../lib/logger')()
 const notify = require('../lib/notify')()
@@ -9,14 +10,13 @@ const mkdirp = require('./mkdirp')
 module.exports = async ({file, spinner, selected, client, instance, options}) => {
   const src = path.relative(process.cwd(), file)
   const uploading = new Set()
-
   const useLog = options.log
   const errorsOnly = options.errorsOnly
 
   if (!uploading.has(src)) {
     const dir = path.dirname(file).replace(path.normalize(selected.d), '')
     const dest = path.join('/', 'Cartridges', selected.v, dir)
-    const text = `Watching ${client} ${instance} [Ctrl-C to Cancel]`
+    const text = chalk.bold(`Watching ${client} ${instance}`).concat(' [Ctrl-C to Cancel]\n')
 
     uploading.add(src)
 
@@ -25,18 +25,17 @@ module.exports = async ({file, spinner, selected, client, instance, options}) =>
         title: `${client} ${instance}`,
         icon: path.join(__dirname, '../icons/', 'sfcc-uploading.png'),
         subtitle: 'UPLOADING ...',
-        message: `${path.basename(src)} => ${dest}`
+        message: `${path.basename(src)}`
       })
     }
 
-    let logMessage = `Uploading ${file.replace(selected.d, '.')} ...`
+    let logMessage = `${chalk.cyan('▲ UPLOADING')} ${file.replace(selected.d, '.')}...`
 
     if (useLog) {
       logger.log(logMessage)
     } else {
-      spinner.stopAndPersist({text: logMessage})
-      spinner.text = text
-      spinner.start()
+      spinner.stop()
+      console.log(logMessage)
     }
 
     try {
@@ -49,7 +48,7 @@ module.exports = async ({file, spinner, selected, client, instance, options}) =>
       }
 
       const tryToMkdir = () => mkdirp(dest, request)
-      const tryToWrite = () => write(src, dest, request)
+      const tryToWrite = () => write(file, dest, request)
 
       await pRetry(tryToMkdir, {retries: 5})
       await pRetry(tryToWrite, {retries: 5})
@@ -59,11 +58,11 @@ module.exports = async ({file, spinner, selected, client, instance, options}) =>
           title: `${client} ${instance}`,
           icon: path.join(__dirname, '../icons/', 'sfcc-success.png'),
           subtitle: 'UPLOAD COMPLETE',
-          message: `${path.basename(src)} => ${dest}`
+          message: `${path.basename(src)}`
         })
       }
 
-      logMessage = `${path.basename(src)} pushed to ${client} ${instance}`
+      logMessage = `${chalk.green('COMPLETE')} ${file.replace(selected.d, '.')}`
 
       if (useLog) {
         logger.log(logMessage)

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra')
 const path = require('path')
-const debug = require('debug')('write')
 const axios = require('axios')
 const followRedirects = require('follow-redirects')
 
@@ -8,11 +7,8 @@ followRedirects.maxBodyLength = 100 * 1024 * 1024
 
 module.exports = (src, dest, options) => {
   try {
-    debug(`Uploading ${src}`)
-
     const url = path.join('/', dest, path.basename(src))
     const stream = fs.createReadStream(src)
-
     const config = Object.assign(
       {
         url,
@@ -24,6 +20,12 @@ module.exports = (src, dest, options) => {
       options
     )
 
-    return axios(config).then(() => url)
+    const request = axios(config)
+      .then(() => url)
+      .catch(error => {
+        console.log('error', error)
+      })
+
+    return request
   } catch (err) {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfcc-cli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5262,19 +5262,13 @@
         "mkdirp": "^0.5.1"
       }
     },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+    "xml-js": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.9.tgz",
+      "integrity": "sha512-Omi8lVfq3q3H0xnGcZKLQhoiOghTGN1xxfabah4FybYN1pyvUzh1X+cJ+vKKY3Zr255y1H5IUAT3u3lznshdbw==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "^1.2.4"
       }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfcc-cli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Command Line Interface for Salesforce Commerce Cloud Sandbox Development",
   "homepage": "https://github.com/redvanworkshop/sfcc-cli#readme",
   "license": "MIT",
@@ -70,7 +70,7 @@
     "prompt": "^1.0.0",
     "prompt-confirm": "^2.0.4",
     "truncate-logs": "^1.0.4",
-    "xml2js": "^0.4.19",
+    "xml-js": "^1.6.9",
     "yargs": "^12.0.5"
   }
 }


### PR DESCRIPTION
#### What's this PR do?

This Commit adds support during project setup to look for those setup scripts and add them to your project config.  Then during the watch process, if a file is being uploaded that was configured to trigger a build, it will do so.

#### Where should the reviewer start?

If you have already setup a project, you will need to do so again with the same setting as last time to update the project config to use this new build setting.

#### How should this be manually tested?

Check to see if you have any `.externalToolBuilders` folders in any of your SFCC cartridges.  If so, this should pick them up and you should see them listed in the `b` property in you `~/.sfcc-cli` file.  Setup will differ based on your project, but should look something like:

```json
{
  "gulp-builder-javascript-builder": {
    "enabled": true,
    "watch": [
      "/app_storefront_core/cartridge/js",
      "/int_QAS/cartridge/js",
      "/int_lcg_cybersourcesa/cartridge/js",
      "/int_procustomer/cartridge/js",
      "/int_tealium/cartridge/js/tealium.js",
      "/int_wheretogetit/cartridge/js"
    ],
    "cmd": {
      "basedir": "/path/to/gulp_builder",
      "exec": "cd /path/to/gulp_builder; gulp js --basedir=/path/to/gulp_builder"
    }
  },
  "gulp-builder-styles-builder": {
    "enabled": true,
    "watch": [
      "/app_patagonia/cartridge/scss",
      "/app_storefront_core/cartridge/scss"
    ],
    "cmd": {
      "basedir": "/path/to/gulp_builder",
      "exec": "cd /path/to/gulp_builder; gulp styles --basedir=/path/to/gulp_builder"
    }
  }
}
```

#### Any background context you want to provide?

Eclipse uses `*.launch` files stored in `.externalToolBuilders` folders inside cartridges in order to handle automagically building for things like Sass and JS Minification.

#### Screenshots (if appropriate)

![screenshot 2019-01-12 at 4 36 21 am](https://user-images.githubusercontent.com/508411/51071813-1eed9b00-1625-11e9-8cbb-47d2cd2917ef.png)

#### What gif best describes this PR or how it makes you feel?

![can_do](https://user-images.githubusercontent.com/508411/51071828-53615700-1625-11e9-9026-a92ff688ab8c.gif)

#### Definition of Done:

- [X] You have actually run this locally and can verify it works
- [X] You have verified that `npm test` passes without issue
- [ ] You have updated the README file (if appropriate) **N/A**
