### PR TITLE
Added troubleshooting information regarding invalid domain certificates

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,4 +9,24 @@ Troubleshooting
 
 <img src="https://octodex.github.com/images/dinotocat.png" width="400" />
 
-#### No Known Issues to Date
+#### Invalid Domain Certificates
+
+For `sfcc-cli` commands that initiate network requests, you may get an error similar to the following:
+
+``Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames: Host: dev09.commerce.myclient.demandware.net. is not in the cert's altnames: DNS:*.demandware.net, DNS:demandware.net``
+
+This is because node cannot verify that the server is valid according to the TLS certificate.  The following command executed in your terminal will temporarily disable this check while you have your terminal session open.
+
+#### Mac and Linux
+
+```bash
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+#### Windows
+
+```bash
+set NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+


### PR DESCRIPTION
#### What's this PR do?

This commit adds documentation regarding how to solve an issue affecting commands that initiate network requests.

#### How should this be manually tested?

Run the terminal command and ensure that commands like `sfcc log` work as expected.

#### Any background context you want to provide?

Not all hostnames appear to be affected by the invalid TLS certificate issue.

#### Definition of Done:

- [X] You have actually run this locally and can verify it works
- [X] You have verified that `npm test` passes without issue
- [X] You have updated the README file (if appropriate)
