### PR TITLE
Adjust log messaging to make it clear if types are being included or …

### DIFF
--- a/lib/tail.js
+++ b/lib/tail.js
@@ -8,10 +8,10 @@ const read = require('./read')
 
 module.exports = async (selected, logs, groups, options) => {
   const including = options.include && options.include.length > 0 ? ` '${options.include.join(', ')}'` : ''
-  const excluding = options.exclude && options.exclude.length > 0 ? ` '${options.exclude.join(', ')}'` : ''
+  const excluding = options.exclude && options.exclude.length > 0 ? ` excluding '${options.exclude.join(', ')}'` : ''
   const filters = options.filter && options.filter.length > 0 ? ` containing '${options.filter}'` : ''
 
-  const text = `Streaming${including}${excluding} Logs${filters} [Ctrl-C to Cancel]`
+  const text = `Streaming${including} Logs${excluding}${filters} [Ctrl-C to Cancel]`
   const spinner = ora(text)
   const output = fn => {
     spinner.stop()


### PR DESCRIPTION
#### What's this PR do?

This PR clarifies the output of `sfcc log` when using the exclude parameter.  Given the following command:

```bash
sfcc log -e customerror,api
```

The messaging is now: 
```
Streaming Logs excluding 'customerror, api' [Ctrl-C to Cancel]
```


Previously it was: 
```
Streaming 'customerror, api' Logs [Ctrl-C to Cancel]
```

#### How should this be manually tested?

Execute the `sfcc log` functionality with and without an excludes argument and verify the messaging.


#### Definition of Done:

- [x] You have actually run this locally and can verify it works
- [x] You have verified that `npm test` passes without issue
- [ ] You have updated the README file (if appropriate)
